### PR TITLE
ensuring the colours don't change when there is an empty group

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: airportscreening
 Title: Run the CMMID Airport Screening Outcomes Shiny App
-Version: 0.0.0.9000
+Version: 0.0.0.9001
 Authors@R: 
     c(
         person(

--- a/R/app.R
+++ b/R/app.R
@@ -59,7 +59,7 @@ run_app <- function() {
     shiny::fluidPage(
       shiny::titlePanel(
         paste0(
-          "Effectiveness of airport screening at detecting",
+          "Effectiveness of airport screening at detecting ",
           "infected travellers"
         )
       ),

--- a/R/app.R
+++ b/R/app.R
@@ -203,7 +203,13 @@ run_app <- function() {
                 round(probs$prop_symp_at_entry[1]))
             )
           ),
-          ordered = TRUE
+          ordered = TRUE,
+          levels = c(
+            "detected at exit screening",
+            "detected as severe on flight",
+            "detected at entry screening",
+            "not detected"
+          )
         )
       ) %>%
         dplyr::mutate(
@@ -219,7 +225,7 @@ run_app <- function() {
         )
 
 
-      waffle_counts <- dplyr::count(waffle_labels, .data$desc) %>%
+      waffle_counts <- dplyr::count(waffle_labels, .data$desc, .drop = FALSE) %>%
         dplyr::mutate(desc_comb = paste(.data$n, .data$desc))
 
       waffle_df <- expand.grid(y = -seq_len(5), x = seq_len(20)) %>%
@@ -248,13 +254,12 @@ run_app <- function() {
         # dplyr::mutate(group=as.factor(group),
         dplyr::mutate(label = emojifont::fontawesome(
           dplyr::case_when(
-            .data$desc == "detected at exit screening" ~ "fa-user",
-            .data$desc == "detected at entry screening" ~ "fa-user-circle",
-            .data$desc == "detected as severe on flight" ~ "fa-user-circle",
-            .data$desc == "not detected" ~ "fa-user-circle"
+            .data$desc == "detected at exit screening"   ~ "fa-user",
+            .data$desc == "detected at entry screening"  ~ "fa-user-circle",
+            .data$desc == "detected as severe on flight" ~ "fa-user-md",
+            .data$desc == "not detected"                 ~ "fa-exclamation-circle"
           )
         ))
-
 
       waffle_colors <- RColorBrewer::brewer.pal(4, name = "Set2")[c(1, 4, 3, 2)]
 

--- a/R/app.R
+++ b/R/app.R
@@ -296,6 +296,8 @@ run_app <- function() {
 
       names(waffle_colors) <- levels(waffle_data$desc_comb)
 
+      library(emojifont)
+      
       waffle_plot <- ggplot2::ggplot(
         data = waffle_data,
         ggplot2::aes(x = .data$x, y = .data$y, colour = .data$desc_comb)

--- a/R/app.R
+++ b/R/app.R
@@ -296,7 +296,7 @@ run_app <- function() {
 
       names(waffle_colors) <- levels(waffle_data$desc_comb)
 
-      library(emojifont)
+      emojifont::load.fontawesome(font = "fontawesome-webfont.ttf")
       
       waffle_plot <- ggplot2::ggplot(
         data = waffle_data,

--- a/R/date_stamp.R
+++ b/R/date_stamp.R
@@ -7,7 +7,7 @@ get_date_stamp <- function() {
   c(
     sprintf(
       paste0(
-        "Last built at %s by B. Quilty, S. Clifford, S. Flasche, R. Eggo",
+        "Last built at %s by B. Quilty, S. Clifford, S. Flasche, R. Eggo ",
         "and other members of CMMID at LSHTM"
       ),
       format(
@@ -17,9 +17,9 @@ get_date_stamp <- function() {
     ),
     paste0(
       "<br/><br/>Download the preprint of our analysis ",
-      '<a href="https://github.com/cmmid/cmmid.github.io/raw/master',
-      "/ncov/airport_screening_report/airport_screening_preprint_2020_01_28.",
-      'pdf">here</a>.<br>Download the code for this app ',
+      '<a href="https://github.com/cmmid/cmmid.github.io/raw/master/ncov/',
+      'airport_screening_report/airport_screening_preprint_2020_01_28.pdf">',
+      'here</a>.<br>Download the code for this app ',
       '<a href="https://github.com/bquilty25/airport_screening">on GitHub</a>',
       "<br/><br/>"
     )


### PR DESCRIPTION
When there were 0 severe in flight, we lost the orange for entering undetected. I've also made minor changes to which fa- icons are used.

I haven't got it to show the empty colour in the legend, but seeing the group is empty I'm not sure this is a problem.

Am demonstrating this app to UQ students so wanted to check it all ran locally seeing as the shinyapps page is long dead.